### PR TITLE
This does not need to be source0, it can just be source

### DIFF
--- a/rdmc.spec.in
+++ b/rdmc.spec.in
@@ -14,7 +14,7 @@ AutoReqProv:    on
 Version:        %VERSION%
 Release:        %RELEASE%
 
-Source0:        ilorest-%{version}.tar.bz2
+Source:         ilorest-%{version}.tar.bz2
 Url:            https://www.hpe.com/info/restfulapi
 Vendor:         Hewlett Packard Enterprise
 Packager:       Hewlett Packard Enterprise


### PR DESCRIPTION
This fixes Cray-HPE's build metadata, which adds a 'Distribution' in under the Source line. The current regex doesn't expect `Source0:` but is looking for `Source:`.

Since `Source0` is meaningless here, this PR just changes it to `Source` to make this repos spec file more generic.