### PR TITLE
CASMTRIAGE-3600 Use Native Python Install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 BUILD_DIR := $(PWD)/dist/rpmbuild
 SRCROOT := $(shell pwd)
 CHROOT_LOCAL_DIR:= $(shell pwd)
-BUILD_METADATA ?= 1~development~$(shell git rev-parse --short HEAD)
 
 NAME:=ilorest
 VERSION := $(shell awk '/Version/{print $$NF; exit}' ${SRCROOT}/docs/slate/source/includes/_changelog.md)
@@ -46,8 +45,8 @@ rdmc.spec: rdmc.spec.in
 
 rpm: doc-ver rpmprep rdmc.spec
 	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' --exclude .git --exclude .gitignore --exclude dist -cvjf ${BUILD_DIR}/SOURCES/${NAME}-${VERSION}.tar.bz2 .
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ts ${BUILD_DIR}/SOURCES/${NAME}-${VERSION}.tar.bz2 --define "_topdir $(BUILD_DIR)"
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ba rdmc.spec --define "_topdir $(BUILD_DIR)"
+	rpmbuild -ts ${BUILD_DIR}/SOURCES/${NAME}-${VERSION}.tar.bz2 --define "_topdir $(BUILD_DIR)"
+	rpmbuild -ba rdmc.spec --define "_topdir $(BUILD_DIR)"
 
 clean:
 	rm -f "$(NAME)-$(VERSION).tar.bz2"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_METADATA ?= 1~development~$(shell git rev-parse --short HEAD)
 
 NAME:=ilorest
 VERSION := $(shell awk '/Version/{print $$NF; exit}' ${SRCROOT}/docs/slate/source/includes/_changelog.md)
-RELEASE:=1
+RELEASE:=2
 SPHINXBUILD:=$(BUILD_DIR)/pylib/Sphinx-1.0.7/sphinx-build.py
 BLOFLY := /net
 #CREATE_CHROOT := /net/blofly.us.rdlabs.hpecorp.net/data/blofly/iss-linux-sdk/chrootbuilder/create_chroot.sh

--- a/rdmc.spec.in
+++ b/rdmc.spec.in
@@ -4,8 +4,8 @@
 #
 
 # norootforbuild
-%global __python /usr/local/bin/python3.8
-%define __pyinstaller /usr/local/bin/pyinstaller
+%global __python /usr/bin/python3
+%define __pyinstaller /usr/bin/pyinstaller
 
 Name:           ilorest
 License:        Copyright 2016-2021 Hewlett Packard Enterprise Development LP


### PR DESCRIPTION
This removes the need to use `/usr/local/bin`, expecting to find the native Python install instead.

For more context, this was done to accommodate a new base image that uses an older GLIBC so that our produced RPM supports older distributions of SLES15. See this for more context: https://github.com/Cray-HPE/metal-ilorest/pull/7